### PR TITLE
clear currentOperand after pressing the equalsButton

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,6 +17,10 @@ class Calculator {
 
   appendNumber(number) {
     if (number === '.' && this.currentOperand.includes('.')) return
+    if (this.conclusion) {
+      this.currentOperand = ""
+      this.conclusion = 0
+    }
     this.currentOperand = this.currentOperand.toString() + number.toString()
   }
 
@@ -54,6 +58,7 @@ class Calculator {
     this.currentOperand = computation
     this.operation = undefined
     this.previousOperand = ''
+    this.conclusion = 1
   }
 
   getDisplayNumber(number) {


### PR DESCRIPTION
Fix: It now clears the previousOperand when user clicks on equalsButton.