### PR TITLE
Fixed chooseOperation

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,7 +21,11 @@ class Calculator {
   }
 
   chooseOperation(operation) {
-    if (this.currentOperand === '') return
+    if (this.currentOperand === '' || this.currentOperand === '-') {
+      if (this.currentOperand === '-' && operation === '-') return; // Prevent adding multiple '-' signs
+      this.currentOperand += operation; // Append the '-' sign to the current operand
+      return;
+    }
     if (this.previousOperand !== '') {
       this.compute()
     }


### PR DESCRIPTION
The first conditional sentence inside the chooseOperation method didn't allow to the calculator to introduce negative numbers as a first input given that everytime the '-' button was pressed it checked for the string and being the string empty it returned nothing, with the new if statement now it can recive negative numbers as input.